### PR TITLE
Update mikro1.rsc

### DIFF
--- a/mikro1.rsc
+++ b/mikro1.rsc
@@ -385,7 +385,6 @@ add disabled=no interface=VLAN_100
 
 # Improve roaming by kicking clients off of weak APs
 /caps-man access-list
-add action=accept interface=any signal-range=-87..120
 add action=reject interface=any signal-range=-120..-88
 
 # TODO: It appears you can't export the certificate private key


### PR DESCRIPTION
Removed access list entry as it's not required.  Put the deny at the top of the rules and everything under it will be accepted (within acceptable signal levels).